### PR TITLE
Some fix and improved Coinbase regex.

### DIFF
--- a/List API Keys/coinbase.yaml
+++ b/List API Keys/coinbase.yaml
@@ -3,6 +3,7 @@ id: coinbase-key
 info:
   name: Coinbase API Key
   author: Penyihir.exe
+  contributors: pl0mo
   severity: info
 
 file:
@@ -12,5 +13,5 @@ file:
     extractors:
       - type: regex
         regex:
-          - "COINBASE_API_KEY(.*?)[a-zA-Z0-9-]{16}"
-          - "COINBASE_API_SECRET(.*?)[a-zA-Z0-9-]{32}"
+          - "(COINBASE|CB)\S?(API)?\S?KEY.+[a-zA-Z0-9]{16}"
+          - "(COINBASE|CB)\S?(API)?\S?SECRET.+[a-zA-Z0-9]{32}"


### PR DESCRIPTION
FIX: Coinbase API keys do not contains any "-" char just lower and upper cased alpha-numeric chars (16 for API key and 32 for API secret).

ADDED: Also added "CB" as possible prefix and changed "_" char to more possible options replaceing it by \S